### PR TITLE
Enable better tree shaking.

### DIFF
--- a/packages/eleventy/src/views/macros.njk
+++ b/packages/eleventy/src/views/macros.njk
@@ -30,7 +30,8 @@
         </a>
       </span>
     </span>
-    <div class="jc-Comment-content">
+
+    <div class="jc-Comment-content" data-jam-comments-component="content">
       {{comment.content | safe}}
     </div>
 

--- a/packages/eleventy/vite.config.js
+++ b/packages/eleventy/vite.config.js
@@ -1,5 +1,6 @@
 import { defineConfig } from "vite";
 import path from "path";
+import { baseRollupOptions } from "../../shared-build-config";
 
 export default defineConfig({
   build: {
@@ -9,6 +10,7 @@ export default defineConfig({
       fileName: (format) => `index.${format}.js`,
     },
     rollupOptions: {
+      ...baseRollupOptions,
       output: {
         dir: "src/assets/dist",
       },

--- a/packages/gatsby/vite.config.js
+++ b/packages/gatsby/vite.config.js
@@ -1,5 +1,6 @@
 import { defineConfig } from "vite";
 import path from "path";
+import { baseRollupOptions } from "../../shared-build-config";
 
 export default defineConfig({
   build: {
@@ -9,6 +10,7 @@ export default defineConfig({
       fileName: (format) => `index.${format}.js`,
     },
     rollupOptions: {
+      ...baseRollupOptions,
       external: ["react", "react-dom"],
       output: {
         globals: {

--- a/packages/next/vite.config.js
+++ b/packages/next/vite.config.js
@@ -1,5 +1,6 @@
 import { defineConfig } from "vite";
 import path from "path";
+import { baseRollupOptions } from "../../shared-build-config";
 
 export default defineConfig({
   build: {
@@ -9,6 +10,7 @@ export default defineConfig({
       fileName: (format) => `index.${format}.js`,
     },
     rollupOptions: {
+      ...baseRollupOptions,
       external: ["react", "react-dom"],
       output: {
         globals: {

--- a/packages/react/vite.config.js
+++ b/packages/react/vite.config.js
@@ -1,5 +1,6 @@
 import { defineConfig } from "vite";
 import path from "path";
+import { baseRollupOptions } from "../../shared-build-config";
 
 export default defineConfig({
   build: {
@@ -10,6 +11,7 @@ export default defineConfig({
       fileName: (format) => `index.${format}.js`,
     },
     rollupOptions: {
+      ...baseRollupOptions,
       external: ["react", "react-dom"],
       output: {
         globals: {

--- a/packages/utilities/client/CommentController.ts
+++ b/packages/utilities/client/CommentController.ts
@@ -214,7 +214,7 @@ export default function CommentController(shell, platform = "") {
    * @return {void}
    */
   const appendComment = (commentData) => {
-    const contentKeysToReplace = ["createdAt", "name"];
+    const contentKeysToReplace = ["createdAt", "name", "content"];
     let commentListToAppendTo = commentList;
 
     commentData.createdAt = `${toPrettyDate(commentData.createdAt)} (pending)`;

--- a/packages/utilities/vite.config.js
+++ b/packages/utilities/vite.config.js
@@ -1,5 +1,6 @@
 import { defineConfig } from "vite";
 import path from "path";
+import { baseRollupOptions } from "../../shared-build-config";
 
 const SCOPES = {
   client: {
@@ -10,6 +11,7 @@ const SCOPES = {
         fileName: (format) => `index.${format}.js`,
       },
       rollupOptions: {
+        ...baseRollupOptions,
         output: {
           dir: "dist-client",
         },
@@ -25,6 +27,7 @@ const SCOPES = {
         fileName: (format) => `index.${format}.js`,
       },
       rollupOptions: {
+        ...baseRollupOptions,
         output: {
           dir: "dist-server",
         },
@@ -39,6 +42,7 @@ const SCOPES = {
         fileName: (format) => `index.${format}.js`,
       },
       rollupOptions: {
+        ...baseRollupOptions,
         output: {
           dir: "dist-shared",
         },

--- a/shared-build-config.js
+++ b/shared-build-config.js
@@ -1,0 +1,3 @@
+export const baseRollupOptions = {
+  treeshake: { moduleSideEffects: false },
+};


### PR DESCRIPTION
Tells Rollup that [none of the imported modules have side effects](https://rollupjs.org/guide/en/), allowing tree shaking to occur on the built packages, which in turn reduces bundle size. 